### PR TITLE
Dynamically load global config implementation. This improves user exp…

### DIFF
--- a/annotations/src/main/java/com/mylaesoftware/ConfigComposer.java
+++ b/annotations/src/main/java/com/mylaesoftware/ConfigComposer.java
@@ -1,0 +1,35 @@
+package com.mylaesoftware;
+
+import com.typesafe.config.Config;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class ConfigComposer {
+
+  private static final String CONFIG_CLASS_NAME = String.format(
+      "%s.%s",
+      GlobalConfig.class.getPackage().getName(),
+      GlobalConfig.IMPLEMENTATION_NAME
+  );
+
+  private ConfigComposer() {
+
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <C extends GlobalConfig> C wire(Config config) {
+    try {
+      ClassLoader loader = Thread.currentThread().getContextClassLoader();
+      Class<C> implementation = (Class<C>) loader.loadClass(CONFIG_CLASS_NAME);
+      Constructor<C> constructor = implementation.getDeclaredConstructor(Config.class);
+      return constructor.newInstance(config);
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | InstantiationException
+        | InvocationTargetException e) {
+      throw new RuntimeException("Error while loading config", e);
+    }
+  }
+}

--- a/annotations/src/main/java/com/mylaesoftware/GlobalConfig.java
+++ b/annotations/src/main/java/com/mylaesoftware/GlobalConfig.java
@@ -1,0 +1,5 @@
+package com.mylaesoftware;
+
+public interface GlobalConfig {
+  String IMPLEMENTATION_NAME = "GlobalConfigImpl";
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
 
 allprojects {
     apply plugin: "java"
-    apply plugin: "idea"
     apply plugin: 'maven-publish'
     apply plugin: "checkstyle"
 


### PR DESCRIPTION
…erience as they will call a static method to wire all their configs without the need of knowing about any underlying GlobalConfig object.

To achieve this an empty interface GlobalConfig has been added and the requirement of assigning the package name to the implementation has been dropped as tha package now defaults to com.mylaesoftware